### PR TITLE
Fix import

### DIFF
--- a/lib/screen/settings_screen.dart
+++ b/lib/screen/settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:amiibo_network/riverpod/theme_provider.dart';
 import 'package:amiibo_network/service/screenshot.dart';
 import 'package:amiibo_network/enum/amiibo_category_enum.dart';
 import 'package:amiibo_network/utils/format_color_on_theme.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -22,7 +23,6 @@ import 'package:amiibo_network/utils/urls_constants.dart';
 import 'package:amiibo_network/service/notification_service.dart';
 import 'package:amiibo_network/model/search_result.dart';
 import 'package:amiibo_network/widget/selected_chip.dart';
-import 'package:amiibo_network/model/amiibo.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({Key? key}) : super(key: key);
@@ -558,19 +558,27 @@ class _BottomBarState extends ConsumerState<BottomBar> {
       else if (file?.files.single.extension != 'json') {
         openSnackBar(translate.errorImporting);
       } else {
-        Map<String, dynamic>? map = await compute(readFile, _path);
-        if (map == null)
+        //final Uint8List data = file!.files.single.bytes!;
+        final AmiiboFile amiiboFile = await compute(readFile, _path);
+        if (amiiboFile is AmiiboFileError) {
+          FirebaseCrashlytics.instance.recordError(
+            amiiboFile.error,
+            amiiboFile.stackTrace,
+          );
           openSnackBar(translate.errorImporting);
-        else {
-          List<Amiibo> amiibos = await compute(entityFromMap, map);
-          await service.update(amiibos);
-          openSnackBar(translate.successImport);
+          return;
         }
+        await service.update((amiiboFile as AmiiboFileData).amiibos);
+        openSnackBar(translate.successImport);
       }
       await FilePicker.platform.clearTemporaryFiles();
-    } on PlatformException catch (e) {
+    } on PlatformException catch (e, s) {
+      FirebaseCrashlytics.instance.recordError(e, s);
       debugPrint(e.message);
       openSnackBar(translate.storagePermission('denied'));
+    } catch (e, s) {
+      FirebaseCrashlytics.instance.recordError(e, s);
+      openSnackBar(translate.errorImporting);
     }
   }
 

--- a/lib/service/notification_service.dart
+++ b/lib/service/notification_service.dart
@@ -37,12 +37,12 @@ class NotificationService {
     required String name,
     required List<Amiibo> amiibos,
   }) async {
-    final map = json.encode(amiibos);
+    final encoder = JsonUtf8Encoder();
     final Map<String, dynamic> args = <String, dynamic>{
       'title': title,
       'actionTitle': actionNotificationTitle,
       'id': 9,
-      'buffer': Uint8List.fromList(map.codeUnits),
+      'buffer': encoder.convert(amiibos),// Uint8List.fromList(map.codeUnits),
       'name': '${name}_$dateTaken',
     };
     //TODO IOS Platform Channel

--- a/lib/service/storage.dart
+++ b/lib/service/storage.dart
@@ -85,7 +85,13 @@ Future<File> createFile(
 AmiiboFile readFile(String path) {
   try {
     final file = File(path);
-    String data = file.readAsStringSync();
+    final uintList = file.readAsBytesSync();
+    /// some malformed json comes with a < 32 ASCII characters, we use this to
+    /// fix it by replacing them with 32 (space)
+    String data = utf8.decode(
+      uintList.map((x) => x < 32 ? 32 : x).toList(),
+      allowMalformed: true,
+    );
     final jResult = jsonDecode(data);
     if (jResult is Map && jResult.containsKey('amiibo')) {
       final data = entityFromMap(jResult as Map<String, dynamic>);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: An Amiibo collection app designed to allow you to keep track of whi
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.1.82+78
+version: 2.1.83+79
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
- Previous JSON had a malformed text  in the amiibo 776, so first we fix the encoding so you can save your json file accordingly and next we fix decoding by replacing all malformed uint8 (values below 32) as a 32 (utf8 for space)